### PR TITLE
Add art on statuses

### DIFF
--- a/opensrp-anc/src/main/assets/json.form/anc_counselling_treatment.json
+++ b/opensrp-anc/src/main/assets/json.form/anc_counselling_treatment.json
@@ -2082,9 +2082,8 @@
         "openmrs_entity": "concept",
         "openmrs_entity_id": "165342AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         "openmrs_data_type": "",
-        "type": "check_box",
+        "type": "native_radio",
         "label": "{{anc_counselling_treatment.step4.increase_energy_counsel_notdone.label}}",
-        "hint": "{{anc_counselling_treatment.step4.increase_energy_counsel_notdone.hint}}",
         "label_text_style": "bold",
         "options": [
           {
@@ -2123,13 +2122,8 @@
         "edit_type": "name",
         "relevance": {
           "step4:increase_energy_counsel_notdone": {
-            "ex-checkbox": [
-              {
-                "or": [
-                  "other"
-                ]
-              }
-            ]
+            "type": "string",
+            "ex": "equalTo(., \"other\")"
           }
         }
       },
@@ -2177,9 +2171,8 @@
         "openmrs_entity": "concept",
         "openmrs_entity_id": "165342AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         "openmrs_data_type": "",
-        "type": "check_box",
+        "type": "native_radio",
         "label": "{{anc_counselling_treatment.step4.balanced_energy_counsel_notdone.label}}",
-        "hint": "{{anc_counselling_treatment.step4.balanced_energy_counsel_notdone.hint}}",
         "label_text_style": "bold",
         "options": [
           {
@@ -2218,13 +2211,8 @@
         "edit_type": "name",
         "relevance": {
           "step4:balanced_energy_counsel_notdone": {
-            "ex-checkbox": [
-              {
-                "or": [
-                  "other"
-                ]
-              }
-            ]
+              "type": "string",
+              "ex": "equalTo(., \"other\")"
           }
         }
       }

--- a/opensrp-anc/src/main/assets/json.form/anc_profile.json
+++ b/opensrp-anc/src/main/assets/json.form/anc_profile.json
@@ -3243,6 +3243,7 @@
     ]
   },
   "step8": {
+    "next": "step9",
     "title": "TB screening history",
     "fields": [
       {
@@ -3380,5 +3381,323 @@
     ]
 
   },
+  "step9": {
+  "title": "Woman's HIV status",
+    "next": "step10",
+  "fields": [
+    {
+      "key": "hiv_test_result",
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_entity_id": "159427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "type": "native_radio",
+      "label": "HIV status",
+      "label_text_style": "bold",
+      "options": [
+        {
+          "key": "positive",
+          "text": "Positive",
+          "openmrs_entity_parent": "",
+          "openmrs_entity": "concept",
+          "openmrs_entity_id": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        },
+        {
+          "key": "negative",
+          "text": "Negative",
+          "openmrs_entity_parent": "",
+          "openmrs_entity": "concept",
+          "openmrs_entity_id": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        },
+        {
+          "key": "unknown",
+          "text": "Unknown",
+          "openmrs_entity_parent": "",
+          "openmrs_entity": "concept",
+          "openmrs_entity_id": "1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      ],
+      "v_required": {
+        "value": true,
+        "err": "Please select HIV status"
+      }
+    },
+    {
+      "key": "test_every_three_months_toaster",
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "",
+      "openmrs_entity_id": "",
+      "type": "toaster_notes",
+      "text": "Test for HIV every 3 months",
+      "text_color": "#000000",
+      "toaster_info_text": "Test for HIV every 3 months",
+      "toaster_info_title": "Test for HIV every 3 months",
+      "toaster_type": "info",
+      "relevance": {
+        "step9:hiv_test_result": {
+          "type": "string",
+          "ex": "equalTo(., \"negative\")"
+        }
+      }
+    },
+    {
+      "key": "hiv_unknown_toaster",
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "",
+      "openmrs_entity_id": "",
+      "type": "toaster_notes",
+      "text": "HIV status unknown please refer for testing",
+      "toaster_type": "warning",
+      "relevance": {
+        "step10:hiv_test_result": {
+          "type": "string",
+          "ex": "equalTo(., \"unknown\")"
+        }
+      }
+    },
+    {
+      "key": "on_art",
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_entity_id": "on_art",
+      "type": "native_radio",
+      "label": "On art?",
+      "options": [
+        {
+          "key": "yes",
+          "text": "Yes"
+        },
+        {
+          "key": "no",
+          "text": "No"
+        }
+      ],
+      "relevance": {
+        "step9:hiv_test_result": {
+          "type": "string",
+          "ex": "equalTo(., \"positive\")"
+        }
+      }},
+    {
+      "key": "reason_not_on_art",
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_entity_id": "reason_on_art",
+      "type": "native_radio",
+      "label": "Reason why not on art",
+      "options": [
+        {
+          "key": "stock_out",
+          "text": "Stock out"
+        },
+        {
+          "key": "expired",
+          "text": "Expired"
+        },
+        {
+          "key": "other",
+          "text": "Other (Specify)"
+        }
+      ],
+      "relevance": {
+        "step9:on_art": {
+          "type": "string",
+          "ex": "equalTo(., \"no\")"
+        }
+      }},
+    {
+      "key": "other_reason_not_art",
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_entity_id": "other_reason_not_art",
+      "type": "edit_text",
+      "hint": "Specify ",
+      "edit_type": "name",
+      "v_required": {
+        "value": true,
+        "err": "Please enter the other reason not on art"
+      },
+      "relevance": {
+        "step9:reason_not_on_art": {
+          "type": "string",
+          "ex": "equalTo(., \"other\")"
+        }
+
+      }},
+    {
+      "key": "not_on_art_toaster",
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "",
+      "openmrs_entity_id": "",
+      "type": "toaster_notes",
+      "text": "Refer to art clinic",
+      "toaster_info_text": "Refer to art clinic",
+      "toaster_info_title": "Refer to art clinic",
+      "toaster_type": "problem",
+      "relevance": {
+        "step9:on_art": {
+          "type": "string",
+          "ex": "equalTo(., \"no\")"
+        }
+      }}
+  ]},
+  "step10": {
+    "title": "Partner's HIV status",
+    "fields": [
+      {
+        "key": "partner_hiv_status",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "159427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "type": "native_radio",
+        "label": " Partners HIV status",
+        "label_text_style": "bold",
+        "options": [
+          {
+            "key": "positive",
+            "text": "Positive",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "key": "negative",
+            "text": "Negative",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "key": "unknown",
+            "text": "Unknown",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "1138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        ],
+        "v_required": {
+          "value": true,
+          "err": "Please select HIV status"
+        }
+      },
+      {
+        "key": "test_every_three_months_toaster",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "toaster_notes",
+        "text": "Test for HIV every 3 months",
+        "text_color": "#000000",
+        "toaster_info_text": "Test for HIV every 3 months",
+        "toaster_info_title": "Test for HIV every 3 months",
+        "toaster_type": "info",
+        "relevance": {
+          "step10:partner_hiv_status": {
+            "type": "string",
+            "ex": "equalTo(., \"negative\")"
+          }
+        }
+      },
+      {
+        "key": "hiv_unknown_toaster",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "toaster_notes",
+        "text": "HIV status unknown please refer for testing",
+        "toaster_type": "warning",
+        "relevance": {
+          "step10:partner_hiv_status": {
+            "type": "string",
+            "ex": "equalTo(., \"unknown\")"
+          }
+        }
+      },
+      {
+        "key": "partner_on_art",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "on_art",
+        "type": "native_radio",
+        "label": "On art?",
+        "options": [
+          {
+            "key": "yes",
+            "text": "Yes"
+          },
+          {
+            "key": "no",
+            "text": "No"
+          }
+        ],
+        "relevance": {
+          "step10:partner_hiv_status": {
+            "type": "string",
+            "ex": "equalTo(., \"positive\")"
+          }
+        }},
+      {
+        "key": "reason_partner_not_on_art",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "reason_on_art",
+        "type": "native_radio",
+        "label": "Reason why not on art",
+        "options": [
+          {
+            "key": "stock_out",
+            "text": "Stock out"
+          },
+          {
+            "key": "expired",
+            "text": "Expired"
+          },
+          {
+            "key": "other",
+            "text": "Other (Specify)"
+          }
+        ],
+        "relevance": {
+          "step10:partner_on_art": {
+            "type": "string",
+            "ex": "equalTo(., \"no\")"
+          }
+        }},
+      {
+        "key": "other_reason_partner_not_art",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "other_reason_not_art",
+        "type": "edit_text",
+        "hint": "Specify ",
+        "edit_type": "name",
+        "v_required": {
+          "value": true,
+          "err": "Please enter the other reason not on art"
+        },
+        "relevance": {
+          "step10:reason_partner_not_on_art": {
+            "type": "string",
+            "ex": "equalTo(., \"other\")"
+          }
+
+        }},
+      {
+        "key": "not_on_art_toaster",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "toaster_notes",
+        "text": "Refer to art clinic",
+        "toaster_info_text": "Refer to art clinic",
+        "toaster_info_title": "Refer to art clinic",
+        "toaster_type": "problem",
+        "relevance": {
+          "step10:partner_on_art": {
+            "type": "string",
+            "ex": "equalTo(., \"no\")"
+          }
+        }}
+    ]},
+
   "properties_file_name": "anc_profile"
 }


### PR DESCRIPTION
- If the option on "Balanced energy and protein dietary supplementation counselling" is "Not done " change the options on reasons from the checklist to radio buttons #234
- If the option on "increase daily energy and protein intake counselling" is "Not done " change the options on reasons from the checklist to radio buttons #233
- Add a section on HIV status and Partner HIV status with options ( Positive, Negative and unknown) If Positive we show a new field on ART ? Yes/No - in the profile and if Not taking provide a reason ( Flag refer to ART clinic - reason why not on ART- Stock out, expired and other (specify) #214